### PR TITLE
Bump to Java 17 and allow building on Mac

### DIFF
--- a/.github/actions/build-env/action.yml
+++ b/.github/actions/build-env/action.yml
@@ -6,7 +6,7 @@ runs:
   using: composite
   steps:
     - name: Prepare build environment
-        uses: ./lingua-franca/.github/actions/prepare-build-env
+      uses: ./lingua-franca/.github/actions/prepare-build-env
     - name: Install VS Code
       run: |
         sudo apt update

--- a/.github/actions/build-env/action.yml
+++ b/.github/actions/build-env/action.yml
@@ -5,12 +5,8 @@ author: Marten Lohstroh <marten@berkeley.edu>
 runs:
   using: composite
   steps:
-    - name: Set up Java JDK
-      uses: actions/setup-java@v1.4.3
-      with:
-        java-version: 11
-    - name: Set up Node.js environment
-      uses: actions/setup-node@v2.1.2
+    - name: Prepare build environment
+        uses: ./lingua-franca/.github/actions/prepare-build-env
     - name: Install VS Code
       run: |
         sudo apt update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out vscode-lingua-franca repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          submodules: recursive
       - name: Set up build environment
         uses: ./.github/actions/build-env
       - name: Build, deploy, and test the VS Code extension

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out vscode-lingua-franca repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up build environment

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,12 +14,12 @@ import * as path from 'path'
     /**
      * Java version required for building (must be a string).
      */
-    static readonly javacVersion = "11"
+    static readonly javacVersion = "17"
 
     /**
      * Regex to capture major version number from "javac --version".
      */
-    static readonly javacRegex = /javac (?<version>\d+)\.\d+\.\d+/
+    static readonly javacRegex = /javac (?<version>\d+)(\.\d+\.\d+)?/
 
     /**
      * Name of the Language and Diagram Server jar.


### PR DESCRIPTION
Changes in PR:
- use Java 17 to build the language server
- fix the detection of the java compiler version on macOS