### PR TITLE
Make "Build and Run" action work irrespective of current working directory

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,7 +79,6 @@ export async function activate(context: ExtensionContext) {
             });
         }
     ));
-    let lastWorkingDirectory: string;
     context.subscriptions.push(commands.registerTextEditorCommand(
         'linguafranca.buildAndRun',
         (textEditor: TextEditor, _) => {
@@ -98,8 +97,7 @@ export async function activate(context: ExtensionContext) {
                         name: runTerminalName,
                         cwd: command[0]
                     });
-                    else if (lastWorkingDirectory !== command[0]) terminal.sendText('cd ' + command[0]);
-                    lastWorkingDirectory = command[0];
+                    terminal.sendText('cd ' + command[0]);
                     terminal.show(true);
                     terminal.sendText(command.slice(1).join(' '));
                 });


### PR DESCRIPTION
This changes the working directory before running any commands. Unfortunately there is no way to check if the user has changed to a different working directory, so this action will be performed unconditionally when the "Build and Run" action is triggered.

The request was to use absolute paths instead of relative paths. This does not do that because this method was easier to implement, and because it might be more robust if we have run commands that behave differently according to the current working directory. If we really want absolute paths, then that is no problem, but it would just take some more testing and changes in the `lingua-franca` main repo.