### PR TITLE
Add button to view output from build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 node_modules/*
 out/*
 .gradle/*
-
+__pycache__/*

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,12 +1,19 @@
 node_modules/
 .git/
+.github/
+.gitmodules/
 lingua-franca/
+__pycache__/*
 src/**
 
 *.vsix
 .gitignore
 .vscodeignore
+CHANGELOG.md
+LICENSE.txt
+jest.config.ts
 tsconfig.json
 tslint.json
+uf.py
 package-lock.json
 developer-notes.md


### PR DESCRIPTION
This change makes it easier to find textual output from the language server. It should allow VS Code users to receive most of the same information that is available from the standalone compiler. The button looks like this:
![Screenshot from 2022-05-16 16-52-46](https://user-images.githubusercontent.com/33707478/168700441-bbb75ad0-48b5-44e8-9ae9-59998522a2bf.png)

The output looks like this:
![Screenshot from 2022-05-16 16-54-00](https://user-images.githubusercontent.com/33707478/168700575-1093e9eb-e650-46fa-ba0b-ac298c5fbd7f.png)

The output includes ALL messages that have been generated by the language server via `System.err` and `System.out`. This may be confusing ("where do the logs start and end?"), but it makes the implementation simple because it means we do not have to worry about what does and does not belong in the output.

[This branch in the main repo](https://github.com/lf-lang/lingua-franca/pull/1174) should be merged first.

Fixes #42.