### PR TITLE
[build] Enable invocation of uf.py via npm run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ A suggested workflow is as follows:
   * To build Java files, `javac` is required.
   * To build Kotlin files, [the Kotlin JVM compiler](https://github.com/JetBrains/kotlin/releases/tag/v1.5.30) `kotlinc` is required. It must be the JVM compiler, not the native compiler.
 2. Ensure that the language and diagram server fat JAR exists. This file is called `./lib/lflang-lds.jar`. If it does not exist, then it is necessary to build it using the build task: `npm run build`.
-3. Run the command: ```./uf.py <CANONICAL_NAME>``` where <CANONICAL_NAME> is either:
+3. Run the command: ```./uf.py <CANONICAL_NAME>``` or ```npm run uf -- <CANONICAL_NAME>```, where <CANONICAL_NAME> is either:
   * the canonical name of a package that you would like to update, or
   * the canonical name of the class that you would like to update. An example would be: ```./uf.py org.lflang.FileConfig```. This will also update any nested classes, and it should work as you would expect even for Kotlin files that do not include exactly one top-level class.
 4. Open `./src/extension.ts` in Visual Studio Code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ A suggested workflow is as follows:
   * To build Java files, `javac` is required.
   * To build Kotlin files, [the Kotlin JVM compiler](https://github.com/JetBrains/kotlin/releases/tag/v1.5.30) `kotlinc` is required. It must be the JVM compiler, not the native compiler.
 2. Ensure that the language and diagram server fat JAR exists. This file is called `./lib/lflang-lds.jar`. If it does not exist, then it is necessary to build it using the build task: `npm run build`.
-3. Run the command: ```./uf.py <CANONICAL_NAME>``` or ```npm run uf -- <CANONICAL_NAME>```, where <CANONICAL_NAME> is either:
+3. Run the command: ```./uf.py <CANONICAL_NAME>``` or ```npm run amend-jar -- <CANONICAL_NAME>```, where <CANONICAL_NAME> is either:
   * the canonical name of a package that you would like to update, or
   * the canonical name of the class that you would like to update. An example would be: ```./uf.py org.lflang.FileConfig```. This will also update any nested classes, and it should work as you would expect even for Kotlin files that do not include exactly one top-level class.
 4. Open `./src/extension.ts` in Visual Studio Code.

--- a/package.json
+++ b/package.json
@@ -148,6 +148,6 @@
         "install": "npm run build && npm run deploy",
         "test": "jest --coverage",
         "test:watch": "jest --watch",
-        "uf": "./uf.py"
+        "amend-jar": "./uf.py"
     }
 }

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
         "deploy": "vsce package && code --install-extension vscode-lingua-franca-*.vsix",
         "install": "npm run build && npm run deploy",
         "test": "jest --coverage",
-        "test:watch": "jest --watch"
+        "test:watch": "jest --watch",
+        "uf": "./uf.py"
     }
 }


### PR DESCRIPTION
This lets one invoke the `uf.py` script using `npm run`, for anyone who prefers that.

This PR is a compromise; it resolves #23 because we have decided that there is not enough practical motivation to justify spending an afternoon to actually port `uf.py`.