### PR TITLE
Fix import statement highlighting

### DIFF
--- a/syntax/lflang.tmLanguage.json
+++ b/syntax/lflang.tmLanguage.json
@@ -247,7 +247,7 @@
             ]
         },
         "import-statement": {
-            "begin": "(?=^import\\b)",
+            "begin": "(?=^\\s*import\\b)",
             "end": ";|(?<=}.*)$|(?<=import[^\\{]*)$",
             "patterns": [
                 {


### PR DESCRIPTION
Previously, import statements were not recognized by the declarative highlighter if they were preceded by whitespace.