### PR TITLE
Support for Java versions > 17

### DIFF
--- a/src/build_lds.ts
+++ b/src/build_lds.ts
@@ -97,7 +97,7 @@ async function checkJavaVersion() {
         const result: VersionCheckResult = await javacVersionChecker()
         switch (result.isCorrect) {
         case true:
-            console.log(`> Java compiler version is ${config.javacVersion}`)
+            console.log(`> Java compiler version is ${result.version}`)
             return
         case false:
             console.log(`> Java compiler version is ${result.version}`)
@@ -116,7 +116,7 @@ async function checkJavaVersion() {
 }
 
 /**
- * Build dependencies and collects produced jars. 
+ * Build dependencies and collects produced jars.
  */
 async function build() {
     await checkInstalled(config.buildDeps)
@@ -136,7 +136,7 @@ async function build() {
     mvn.execute(['clean', 'package', '-P', 'lds', '-U'], { 'skipTests' : 'true' })
     .then(() => {
         copyJars()
-    });    
+    });
 }
 
 /**

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,12 +4,19 @@
  */
 export class Version {
     public static readonly regex = /\bv?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/;
+    private static readonly permissiveRegex = /\b(?<major>\d{1,3})\b/;
     readonly major: number;
     readonly minor: number;
     readonly patch: number;
 
-    constructor(version: string) {
+    constructor(version: string, permissive?: boolean) {
         if (!Version.regex.test(version)) {
+            if (permissive && Version.permissiveRegex.test(version)) {
+                this.major = parseInt(version.match(Version.permissiveRegex).groups.major, 10);
+                this.minor = 0;
+                this.patch = 0;
+                return;
+            }
             throw new Error(`${version} does not describe a valid version number.`);
         }
         const result = version.match(Version.regex);

--- a/src/version_checker.ts
+++ b/src/version_checker.ts
@@ -79,7 +79,7 @@ const theBetterOfEither: VersionCheckerCombiner = (check0, check1) => async () =
     return zeroth;
 };
 
-export const javaVersionChecker = basicChecker(config.javaVersion, 'java -version 2>&1', false);
+export const javaVersionChecker = basicChecker(config.javaVersion, 'java -version 2>&1', false, true);
 export const javacVersionChecker = basicChecker(config.javacVersion, 'javac -version 2>&1', false, true);
 export const python3AliasVersionChecker = basicChecker(config.pythonVersion, 'python3 -V', false);
 export const pythonAliasVersionChecker = basicChecker(config.pythonVersion, 'python -V', false);

--- a/src/version_checker.ts
+++ b/src/version_checker.ts
@@ -61,8 +61,8 @@ const theBetterOfEither: VersionCheckerCombiner = (check0, check1) => async () =
     return zeroth;
 };
 
-export const javaVersionChecker = basicChecker(config.javaVersion, 'java -version 2>&1', true);
-export const javacVersionChecker = basicChecker(config.javacVersion, 'javac -version 2>&1', true);
+export const javaVersionChecker = basicChecker(config.javaVersion, 'java -version 2>&1', false);
+export const javacVersionChecker = basicChecker(config.javacVersion, 'javac -version 2>&1', false);
 export const python3AliasVersionChecker = basicChecker(config.pythonVersion, 'python3 -V', false);
 export const pythonAliasVersionChecker = basicChecker(config.pythonVersion, 'python -V', false);
 export const python3VersionChecker = theBetterOfEither(


### PR DESCRIPTION
This change makes the check for Java 17 less strict and also permits newer versions.