### PR TITLE
Fix "Build and Run" command with paths that contain spaces

### DIFF
--- a/src/build_commands.ts
+++ b/src/build_commands.ts
@@ -61,7 +61,7 @@ const buildAndRun = (withLogs: MessageShowerTransformer, client: LanguageClient)
                 return;
             }
             const terminal = getTerminal('Lingua Franca: Run', command[0]);
-            terminal.sendText(`cd ${command[0]}`);
+            terminal.sendText(`cd "${command[0]}"`);
             terminal.show(true);
             terminal.sendText(command.slice(1).join(' '));
         });


### PR DESCRIPTION
Added escape of path in change directory command.
This fixes errors caused by paths containing a space.