### PR TITLE
Run dependency tests only if relevant files change

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -24,3 +24,21 @@ runs:
     - name: Build the VS Code extension
       run: npm install --ignore-scripts
       shell: bash
+    - name: Install pylint
+      run: python3 -m pip install pylint
+      shell: bash
+    - name: Install pnpm
+      run: npm i -g pnpm
+      shell: bash
+    - name: Setup Rust
+      uses: ATiltedTree/setup-rust@v1
+      with:
+        rust-version: ${{ matrix.rust }}
+        components: clippy
+    - name: Install RTI
+      run: |
+        cd lingua-franca
+        .github/actions/install-rti/install.sh
+        cd ..
+      shell: bash
+      if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,69 +17,10 @@ jobs:
         rust: [nightly]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@main
-      - name: Install pylint
-        run: python3 -m pip install pylint
-      - name: Install pnpm
-        run: npm i -g pnpm
-      - name: Setup Rust
-        uses: ATiltedTree/setup-rust@v1
-        with:
-          rust-version: ${{ matrix.rust }}
-          components: clippy
-      - name: Install RTI
-        run: |
-          cd lingua-franca
-          .github/actions/install-rti/install.sh
-          cd ..
-        shell: bash
-        if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
+      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@disable-dependency-tests
       - name: Run tests (Linux)
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test
         if: ${{ runner.os == 'Linux' }}
       - name: Run tests (non-Linux)
         run: npm run test
-        if: ${{ runner.os != 'Linux' }}
-  test-dependencies-outdated:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@main
-      - name: Downgrade dependencies
-        run: |
-          pip install -I pylint==2.10.0
-          rustup default 1.26.0
-      - name: Run tests (Linux)
-        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-outdated
-        if: ${{ runner.os == 'Linux' }}
-      - name: Run tests (non-Linux)
-        run: npm run test-dependencies-outdated
-        if: ${{ runner.os != 'Linux' }}
-  test-dependencies-missing-extended:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@main
-      - name: Run tests (Linux)
-        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-extended
-        if: ${{ runner.os == 'Linux' }}
-      - name: Run tests (non-Linux)
-        run: npm run test-dependencies-missing-extended
-        if: ${{ runner.os != 'Linux' }}
-  test-dependencies-missing-basic:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@main
-      - name: Run tests (Linux)
-        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-basic
-        if: ${{ runner.os == 'Linux' }}
-      - name: Run tests (non-Linux)
-        run: npm run test-dependencies-missing-basic
         if: ${{ runner.os != 'Linux' }}

--- a/.github/workflows/dependency-tests.yml
+++ b/.github/workflows/dependency-tests.yml
@@ -1,0 +1,71 @@
+# Main workflow for testing the Lingua Franca Visual Studio Code Extension
+name: CI
+
+on:
+  # Trigger this workflow on push events, but only on main.
+  push:
+    branches:
+      - main
+    paths:
+      - '**/check_dependencies.ts'
+      - '**/version_checker.ts'
+      - '**/version.ts'
+  # Trigger this workflow also on pull_request events.
+  pull_request:
+    paths:
+    - '**/check_dependencies.ts'
+    - '**/version_checker.ts'
+    - '**/version.ts'
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [nightly]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@main
+  test-dependencies-outdated:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@main
+      - name: Downgrade dependencies
+        run: |
+          pip install -I pylint==2.10.0
+          rustup default 1.26.0
+      - name: Run tests (Linux)
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-outdated
+        if: ${{ runner.os == 'Linux' }}
+      - name: Run tests (non-Linux)
+        run: npm run test-dependencies-outdated
+        if: ${{ runner.os != 'Linux' }}
+  test-dependencies-missing-extended:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@main
+      - name: Run tests (Linux)
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-extended
+        if: ${{ runner.os == 'Linux' }}
+      - name: Run tests (non-Linux)
+        run: npm run test-dependencies-missing-extended
+        if: ${{ runner.os != 'Linux' }}
+  test-dependencies-missing-basic:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@main
+      - name: Run tests (Linux)
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-basic
+        if: ${{ runner.os == 'Linux' }}
+      - name: Run tests (non-Linux)
+        run: npm run test-dependencies-missing-basic
+        if: ${{ runner.os != 'Linux' }}

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,10 +6,6 @@
 import * as path from 'path'
 import { Version } from './version';
 
-const defaultDict = (defaultValue: any) => (dict: Object) => new Proxy(dict, {
-    get: (target: Object, name: string) => name in target ? target[name] : defaultValue
-});
-
 /** Executables that have to be on the PATH in order to build. */
 export const buildDeps = ['code', 'jar', 'javac', 'mvn', 'python3'];
 


### PR DESCRIPTION
The dependency tests fail more often than not and pertain to code that has not been modified in a long time, so we should run them selectively.