### PR TITLE
Update message for missing dependencies

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,6 +1,11 @@
 name: Build
 description: Set up repository and install dependencies required to build extension.
 
+inputs:
+  partial:
+    required: false
+    default: "true"
+
 runs:
   using: "composite"
   steps:
@@ -27,18 +32,21 @@ runs:
     - name: Install pylint
       run: python3 -m pip install pylint
       shell: bash
+      if: ${{ inputs.partial != 'false' }}
     - name: Install pnpm
       run: npm i -g pnpm
       shell: bash
+      if: ${{ inputs.partial != 'false' }}
     - name: Setup Rust
       uses: ATiltedTree/setup-rust@v1
       with:
         rust-version: stable
         components: clippy
+      if: ${{ inputs.partial != 'false' }}
     - name: Install RTI
       run: |
         cd lingua-franca
         .github/actions/install-rti/install.sh
         cd ..
       shell: bash
-      if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
+      if: ${{ (runner.os == 'macOS' || runner.os == 'Linux') && inputs.partial != 'false' }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,11 +1,6 @@
 name: Build
 description: Set up repository and install dependencies required to build extension.
 
-inputs:
-  partial:
-    required: false
-    default: "true"
-
 runs:
   using: "composite"
   steps:
@@ -32,21 +27,3 @@ runs:
     - name: Install pylint
       run: python3 -m pip install pylint
       shell: bash
-      if: ${{ inputs.partial != 'false' }}
-    - name: Install pnpm
-      run: npm i -g pnpm
-      shell: bash
-      if: ${{ inputs.partial != 'false' }}
-    - name: Setup Rust
-      uses: ATiltedTree/setup-rust@v1
-      with:
-        rust-version: stable
-        components: clippy
-      if: ${{ inputs.partial != 'false' }}
-    - name: Install RTI
-      run: |
-        cd lingua-franca
-        .github/actions/install-rti/install.sh
-        cd ..
-      shell: bash
-      if: ${{ (runner.os == 'macOS' || runner.os == 'Linux') && inputs.partial != 'false' }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Setup Rust
       uses: ATiltedTree/setup-rust@v1
       with:
-        rust-version: ${{ matrix.rust }}
+        rust-version: stable
         components: clippy
     - name: Install RTI
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      partial:
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  build:
+    steps:
+      - name: Check out vscode-lingua-franca repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 1
+      - name: Set up Java 17
+        run: |
+          echo "$JAVA_HOME_17_X64/bin" >> $GITHUB_PATH
+          echo "org.gradle.java.home=${JAVA_HOME_17_X64//\\/\/}" >> gradle.properties
+          echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+        shell: bash
+      - name: Check settings
+        run: |
+          echo $(which java)
+          cat gradle.properties
+          echo $JAVA_HOME
+        shell: bash
+      - name: Build the VS Code extension
+        run: npm install --ignore-scripts
+        shell: bash
+      - name: Install pylint
+        run: python3 -m pip install pylint
+        shell: bash
+      - name: Install pnpm
+        run: npm i -g pnpm
+        shell: bash
+      - name: Setup Rust
+        uses: ATiltedTree/setup-rust@v1
+        with:
+          rust-version: stable
+          components: clippy
+      - name: Install RTI
+        run: |
+          cd lingua-franca
+          .github/actions/install-rti/install.sh
+          cd ..
+        shell: bash
+        if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}

--- a/.github/workflows/dependency-tests.yml
+++ b/.github/workflows/dependency-tests.yml
@@ -7,15 +7,15 @@ on:
     branches:
       - main
     paths:
-      - '**/check_dependencies.ts'
-      - '**/version_checker.ts'
-      - '**/version.ts'
+      - "**/check_dependencies.ts"
+      - "**/version_checker.ts"
+      - "**/version.ts"
   # Trigger this workflow also on pull_request events.
   pull_request:
     paths:
-    - '**/check_dependencies.ts'
-    - '**/version_checker.ts'
-    - '**/version.ts'
+      - "**/check_dependencies.ts"
+      - "**/version_checker.ts"
+      - "**/version.ts"
 
 jobs:
   test:
@@ -33,6 +33,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
+        with:
+          partial: "true"
       - name: Downgrade dependencies
         run: |
           pip install -I pylint==2.10.0
@@ -50,6 +52,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
+        with:
+          partial: true
       - name: Run tests (Linux)
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-extended
         if: ${{ runner.os == 'Linux' }}
@@ -63,6 +67,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
+        with:
+          partial: "true"
       - name: Run tests (Linux)
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-basic
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/dependency-tests.yml
+++ b/.github/workflows/dependency-tests.yml
@@ -18,14 +18,6 @@ on:
       - "**/version.ts"
 
 jobs:
-  test:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [nightly]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
   test-dependencies-outdated:
     strategy:
       matrix:
@@ -53,12 +45,12 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
-      - name: Run tests (Linux)
-        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-extended
-        if: ${{ runner.os == 'Linux' }}
       - name: Uninstall dependencies
         run: |
           python3 -m pip uninstall -y pylint
+      - name: Run tests (Linux)
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-extended
+        if: ${{ runner.os == 'Linux' }}
       - name: Run tests (non-Linux)
         run: npm run test-dependencies-missing-extended
         if: ${{ runner.os != 'Linux' }}

--- a/.github/workflows/dependency-tests.yml
+++ b/.github/workflows/dependency-tests.yml
@@ -25,14 +25,14 @@ jobs:
         rust: [nightly]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@main
+      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
   test-dependencies-outdated:
     strategy:
       matrix:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@main
+      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
       - name: Downgrade dependencies
         run: |
           pip install -I pylint==2.10.0
@@ -49,7 +49,7 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@main
+      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
       - name: Run tests (Linux)
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-extended
         if: ${{ runner.os == 'Linux' }}
@@ -62,7 +62,7 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@main
+      - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
       - name: Run tests (Linux)
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-basic
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/dependency-tests.yml
+++ b/.github/workflows/dependency-tests.yml
@@ -33,8 +33,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
-        with:
-          partial: "true"
       - name: Downgrade dependencies
         run: |
           pip install -I pylint==2.10.0
@@ -52,8 +50,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
-        with:
-          partial: true
       - name: Run tests (Linux)
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-extended
         if: ${{ runner.os == 'Linux' }}
@@ -67,8 +63,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
-        with:
-          partial: "true"
       - name: Run tests (Linux)
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-basic
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/dependency-tests.yml
+++ b/.github/workflows/dependency-tests.yml
@@ -33,6 +33,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
+      - name: Uninstall dependencies
+        run: |
+          python3 -m pip uninstall pylint
       - name: Downgrade dependencies
         run: |
           pip install -I pylint==2.10.0
@@ -53,6 +56,9 @@ jobs:
       - name: Run tests (Linux)
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test-dependencies-missing-extended
         if: ${{ runner.os == 'Linux' }}
+      - name: Uninstall dependencies
+        run: |
+          python3 -m pip uninstall pylint
       - name: Run tests (non-Linux)
         run: npm run test-dependencies-missing-extended
         if: ${{ runner.os != 'Linux' }}

--- a/.github/workflows/dependency-tests.yml
+++ b/.github/workflows/dependency-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: lf-lang/vscode-lingua-franca/.github/actions/build@update-error-message
       - name: Uninstall dependencies
         run: |
-          python3 -m pip uninstall pylint
+          python3 -m pip uninstall -y pylint
       - name: Downgrade dependencies
         run: |
           pip install -I pylint==2.10.0
@@ -58,7 +58,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
       - name: Uninstall dependencies
         run: |
-          python3 -m pip uninstall pylint
+          python3 -m pip uninstall -y pylint
       - name: Run tests (non-Linux)
         run: npm run test-dependencies-missing-extended
         if: ${{ runner.os != 'Linux' }}

--- a/src/check_dependencies.ts
+++ b/src/check_dependencies.ts
@@ -268,6 +268,8 @@ export const watcherConfig: CheckSet[] = [
     },
 ];
 
+export const caveat = 'If this dependency is already on your system, start VS Code from a terminal emulator so that VS Code sees the same value of your PATH that you see in your terminal.'
+
 /**
  * Return a dependency checker that returns whether the given dependency is satisfied and, as a side
  * effect, warns the user if not.
@@ -277,11 +279,10 @@ const checkDependency: UserFacingVersionCheckerMaker = (dependency: DependencyIn
         (MessageDisplayHelper: MessageDisplayHelper) => async () => {
     const checkerResult: versionChecker.VersionCheckResult = await dependency.checker();
     if (checkerResult.isCorrect) return true;
-    const caveat = "If this dependency is already on your system, start VS Code from a terminal emulator so that VS Code sees the same value of your PATH that you see in your terminal."
     const message: string = (await (checkerResult.isCorrect === false ? (
         dependency.wrongVersionMessage?.(checkerResult)
         ?? dependency.message(checkerResult)
-    ) : dependency.message(checkerResult))) + "\n" + caveat;
+    ) : dependency.message(checkerResult))) + ' ' + caveat;
     const installCommand: InstallCommand = await dependency.installCommand?.(checkerResult);
     if (!installCommand && !dependency.installLink) {
         MessageDisplayHelper(message);
@@ -321,7 +322,7 @@ export const checkerFor: CheckerGetter = (name: Dependency) => {
 };
 
 const doDependencyCheck = (document: vscode.TextDocument) => {
-    if (document.languageId != "lflang") return;
+    if (document.languageId != 'lflang') return;
     for (const checkSet of watcherConfig.filter(it => it.regexp.test(document.getText()))) {
         for (const check of checkSet.checks.filter(
             it => !it.alreadyChecked || (it.isEssential && !it.satisfied))

--- a/src/check_dependencies.ts
+++ b/src/check_dependencies.ts
@@ -277,10 +277,11 @@ const checkDependency: UserFacingVersionCheckerMaker = (dependency: DependencyIn
         (MessageDisplayHelper: MessageDisplayHelper) => async () => {
     const checkerResult: versionChecker.VersionCheckResult = await dependency.checker();
     if (checkerResult.isCorrect) return true;
-    const message: string = await (checkerResult.isCorrect === false ? (
+    const caveat = "If this dependency is already on your system, start VS Code from a terminal emulator so that VS Code sees the same value of your PATH that you see in your terminal."
+    const message: string = (await (checkerResult.isCorrect === false ? (
         dependency.wrongVersionMessage?.(checkerResult)
         ?? dependency.message(checkerResult)
-    ) : dependency.message(checkerResult));
+    ) : dependency.message(checkerResult))) + "\n" + caveat;
     const installCommand: InstallCommand = await dependency.installCommand?.(checkerResult);
     if (!installCommand && !dependency.installLink) {
         MessageDisplayHelper(message);

--- a/src/test/check_dependencies.test.ts
+++ b/src/test/check_dependencies.test.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import chai from 'chai';
 import spies from 'chai-spies';
 import { expect } from 'chai';
-import { after, Context } from 'mocha';
+import { after } from 'mocha';
 import { MessageDisplayHelper } from '../utils';
 import * as http from 'http';
 import * as url from 'url';
@@ -60,7 +60,7 @@ suite('test dependency checking',  () => {
                 this.test.skip();
             case DependencyStatus.Missing0:
                 await expectFailure(dependency, spy);
-                expect(spy).to.have.been.called.with(depMissingMessage);
+                expect(spy).to.have.been.called.with(depMissingMessage + " " + checkDependencies.caveat);
                 break;
             case DependencyStatus.Missing1:
                 this.test.skip();
@@ -96,7 +96,7 @@ suite('test dependency checking',  () => {
             this.test.skip();
         case DependencyStatus.Missing1:
             await expectFailure(Dependency.Pylint, spy);
-            expect(spy).to.have.been.called.with(checkDependencies.pylintMessage);
+            expect(spy).to.have.been.called.with(checkDependencies.pylintMessage + " " + checkDependencies.caveat);
             await new Promise(resolve => setTimeout(resolve, maxInstallationTimeMilliseconds));
             await expectSuccess(Dependency.Pylint, spy);
             break;
@@ -105,7 +105,7 @@ suite('test dependency checking',  () => {
             expect(spy).to.have.been.called.with(
                 `The Lingua Franca language server is tested with Pylint version `
                     + `${config.pylintVersion.major}.${config.pylintVersion.minor} and newer, but `
-                    + `the version detected on your system is 2.10.0.`
+                    + `the version detected on your system is 2.10.0. ${checkDependencies.caveat}`
             );
             await new Promise(resolve => setTimeout(resolve, maxInstallationTimeMilliseconds));
             await expectSuccess(Dependency.Pylint, spy);
@@ -126,13 +126,13 @@ suite('test dependency checking',  () => {
             break;
         case DependencyStatus.Missing0:
             await expectFailure(Dependency.Pnpm, spy);
-            expect(spy).to.have.been.called.with(checkDependencies.pnpmMessage);
+            expect(spy).to.have.been.called.with(checkDependencies.pnpmMessage + " " + checkDependencies.caveat);
             break;
         case DependencyStatus.Missing1:
             await expectFailure(Dependency.Pnpm, spy);
             expect(spy).to.have.been.called.with(
                 'To prevent an accumulation of replicated dependencies when compiling LF programs '
-                + 'with the TypeScript target, it is highly recommended to install pnpm globally.'
+                + 'with the TypeScript target, it is highly recommended to install pnpm globally.' + " " + checkDependencies.caveat
             );
             await new Promise(resolve => setTimeout(resolve, maxInstallationTimeMilliseconds));
             await expectSuccess(Dependency.Pnpm, spy);
@@ -158,7 +158,7 @@ suite('test dependency checking',  () => {
             break;
         case DependencyStatus.Missing0:
             await expectFailure(Dependency.Rust, spy);
-            expect(spy).to.have.been.called.with(checkDependencies.rustMessage);
+            expect(spy).to.have.been.called.with(checkDependencies.rustMessage + " " + checkDependencies.caveat);
             break;
         case DependencyStatus.Missing1:
             this.test.skip();
@@ -180,7 +180,7 @@ suite('test dependency checking',  () => {
             this.test.skip();
         case DependencyStatus.Missing1:
             await expectFailure(Dependency.Rti, spy);
-            expect(spy).to.have.been.called.with(checkDependencies.rtiMessage);
+            expect(spy).to.have.been.called.with(checkDependencies.rtiMessage + " " + checkDependencies.caveat);
             break;
         default:
             throw new Error('unreachable');

--- a/src/version_checker.ts
+++ b/src/version_checker.ts
@@ -104,7 +104,7 @@ export const rtiVersionChecker = async () => {
     // TODO: Update when #76 is addressed: https://github.com/lf-lang/reactor-c/issues/76
     let exists: boolean;
     try {
-        exists = (await which("RTI")).length > 0;
+        exists = (await which('RTI')).length > 0;
     } catch (e) {
         return { version: new Version('0.0.0'), isCorrect: null };
     }


### PR DESCRIPTION
This is mostly relevant to packages managed by NVM, which seem to be located in a special place.

Fixes #119. This does not actually fix the PATH, but it does at least update the error message so that the message suggests the correct solution and is not misleading.

I believe that we can fix the PATH if we really want to by doing some hacking with the embedded terminal. However, I anticipate that such a solution would cause bugs and maintainability problems that I do not want to face right now.