### PR TITLE
VS code engine bumped to `1.63.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "which": "^2.0.2"
             },
             "engines": {
-                "vscode": "^1.49.0"
+                "vscode": "^1.63.0"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "url": "https://github.com/lf-lang/vscode-lingua-franca/issues"
     },
     "engines": {
-        "vscode": "^1.49.0"
+        "vscode": "^1.63.0"
     },
     "categories": [
         "Programming Languages"


### PR DESCRIPTION
Upgrade necessary to be able to use VS Code's pre-release option:

> Pre-release extensions are supported after VS Code version 1.63.0 and so all pre-release extensions needs to set engines.vscode value in their package.json to >= 1.63.0.
