### PR TITLE
Package `vsce` renamed to `@vscode/vsce`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "@types/vscode": "^1.49.0",
                 "@types/which": "^2.0.1",
                 "@vscode/test-electron": "^2.1.3",
+                "@vscode/vsce": "^2.21.0",
                 "chai": "^4.3.4",
                 "chai-spies": "^1.0.0",
                 "colorette": "^2.0.16",
@@ -38,7 +39,6 @@
                 "ts-node": "^10.9.1",
                 "typescript": "^4.6.4",
                 "url-exist": "^3.0.0",
-                "vsce": "^2.15.0",
                 "vscode-oniguruma": "^1.7.0",
                 "vscode-textmate": "^9.0.0",
                 "which": "^2.0.2"
@@ -297,9 +297,9 @@
             }
         },
         "node_modules/@vscode/test-electron/node_modules/semver": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-            "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -309,6 +309,100 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/@vscode/vsce": {
+            "version": "2.21.0",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.21.0.tgz",
+            "integrity": "sha512-KuxYqScqUY/duJbkj9eE2tN2X/WJoGAy54hHtxT3ZBkM6IzrOg7H7CXGUPBxNlmqku2w/cAjOUSrgIHlzz0mbA==",
+            "dev": true,
+            "dependencies": {
+                "azure-devops-node-api": "^11.0.1",
+                "chalk": "^2.4.2",
+                "cheerio": "^1.0.0-rc.9",
+                "commander": "^6.2.1",
+                "glob": "^7.0.6",
+                "hosted-git-info": "^4.0.2",
+                "jsonc-parser": "^3.2.0",
+                "leven": "^3.1.0",
+                "markdown-it": "^12.3.2",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.3",
+                "parse-semver": "^1.1.1",
+                "read": "^1.0.7",
+                "semver": "^7.5.2",
+                "tmp": "^0.2.1",
+                "typed-rest-client": "^1.8.4",
+                "url-join": "^4.0.1",
+                "xml2js": "^0.5.0",
+                "yauzl": "^2.3.1",
+                "yazl": "^2.2.2"
+            },
+            "bin": {
+                "vsce": "vsce"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "optionalDependencies": {
+                "keytar": "^7.7.0"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/commander": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/xml2js": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+            "dev": true,
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/abort-controller": {
@@ -346,6 +440,7 @@
             "version": "2.1.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -376,12 +471,14 @@
         "node_modules/aproba": {
             "version": "1.2.0",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/are-we-there-yet": {
             "version": "1.1.7",
             "dev": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -440,7 +537,8 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
@@ -454,6 +552,7 @@
             "version": "4.1.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -464,6 +563,7 @@
             "version": "3.6.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -521,6 +621,7 @@
                 }
             ],
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -686,7 +787,8 @@
         "node_modules/chownr": {
             "version": "1.1.4",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/cliui": {
             "version": "7.0.4",
@@ -742,6 +844,7 @@
             "version": "1.1.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -782,7 +885,8 @@
         "node_modules/console-control-strings": {
             "version": "1.1.0",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
@@ -899,6 +1003,7 @@
             "version": "4.2.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "mimic-response": "^2.0.0"
             },
@@ -922,6 +1027,7 @@
             "version": "0.6.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=4.0.0"
             }
@@ -929,12 +1035,14 @@
         "node_modules/delegates": {
             "version": "1.0.0",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/detect-libc": {
             "version": "1.0.3",
             "dev": true,
             "license": "Apache-2.0",
+            "optional": true,
             "bin": {
                 "detect-libc": "bin/detect-libc.js"
             },
@@ -1010,6 +1118,7 @@
             "version": "1.4.4",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -1416,6 +1525,7 @@
             "version": "2.0.3",
             "dev": true,
             "license": "(MIT OR WTFPL)",
+            "optional": true,
             "engines": {
                 "node": ">=6"
             }
@@ -1498,7 +1608,8 @@
         "node_modules/fs-constants": {
             "version": "1.0.0",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -1514,6 +1625,7 @@
             "version": "2.7.4",
             "dev": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -1557,7 +1669,8 @@
         "node_modules/github-from-package": {
             "version": "0.0.0",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/glob": {
             "version": "8.1.0",
@@ -1650,7 +1763,8 @@
         "node_modules/has-unicode": {
             "version": "2.0.1",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/he": {
             "version": "1.2.0",
@@ -1706,7 +1820,8 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "optional": true
         },
         "node_modules/immediate": {
             "version": "3.0.6",
@@ -1740,7 +1855,8 @@
         "node_modules/ini": {
             "version": "1.3.8",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
@@ -1783,6 +1899,7 @@
             "version": "1.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "number-is-nan": "^1.0.0"
             },
@@ -1862,6 +1979,12 @@
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
+        "node_modules/jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "dev": true
+        },
         "node_modules/jszip": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -1879,6 +2002,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "node-addon-api": "^3.0.0",
                 "prebuild-install": "^6.0.0"
@@ -2170,6 +2294,7 @@
             "version": "2.1.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=8"
             },
@@ -2240,7 +2365,8 @@
         "node_modules/mkdirp-classic": {
             "version": "0.5.3",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/mocha": {
             "version": "10.2.0",
@@ -2613,7 +2739,8 @@
         "node_modules/napi-build-utils": {
             "version": "1.0.2",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/ncp": {
             "version": "2.0.0",
@@ -2644,14 +2771,17 @@
             "version": "2.30.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "semver": "^5.4.1"
             }
         },
         "node_modules/node-abi/node_modules/semver": {
-            "version": "5.7.1",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
-            "license": "ISC",
+            "optional": true,
             "bin": {
                 "semver": "bin/semver"
             }
@@ -2659,7 +2789,8 @@
         "node_modules/node-addon-api": {
             "version": "3.2.1",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/node-domexception": {
             "version": "1.0.0",
@@ -2722,9 +2853,9 @@
             "dev": true
         },
         "node_modules/normalize-package-data/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver"
@@ -2742,6 +2873,7 @@
             "version": "4.1.2",
             "dev": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -2764,6 +2896,7 @@
             "version": "1.0.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2772,6 +2905,7 @@
             "version": "4.1.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2861,9 +2995,10 @@
             }
         },
         "node_modules/parse-semver/node_modules/semver": {
-            "version": "5.7.1",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
-            "license": "ISC",
             "bin": {
                 "semver": "bin/semver"
             }
@@ -2941,6 +3076,7 @@
             "version": "6.1.4",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "detect-libc": "^1.0.3",
                 "expand-template": "^2.0.3",
@@ -2981,6 +3117,7 @@
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -3021,6 +3158,7 @@
             "version": "1.2.8",
             "dev": true,
             "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "optional": true,
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -3201,8 +3339,9 @@
             "license": "ISC"
         },
         "node_modules/semver": {
-            "version": "6.3.0",
-            "license": "ISC",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -3218,7 +3357,8 @@
         "node_modules/set-blocking": {
             "version": "2.0.0",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/setimmediate": {
             "version": "1.0.5",
@@ -3242,7 +3382,8 @@
         "node_modules/signal-exit": {
             "version": "3.0.7",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/simple-concat": {
             "version": "1.0.1",
@@ -3261,12 +3402,14 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/simple-get": {
             "version": "3.1.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "decompress-response": "^4.2.0",
                 "once": "^1.3.1",
@@ -3332,6 +3475,7 @@
             "version": "1.0.2",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3345,6 +3489,7 @@
             "version": "3.0.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "ansi-regex": "^2.0.0"
             },
@@ -3368,6 +3513,7 @@
             "version": "2.0.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3399,6 +3545,7 @@
             "version": "2.1.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -3410,6 +3557,7 @@
             "version": "2.2.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -3425,6 +3573,7 @@
             "version": "3.6.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -3532,6 +3681,7 @@
             "version": "0.6.0",
             "dev": true,
             "license": "Apache-2.0",
+            "optional": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -3647,79 +3797,6 @@
                 "spdx-expression-parse": "^3.0.0"
             }
         },
-        "node_modules/vsce": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.15.0.tgz",
-            "integrity": "sha512-P8E9LAZvBCQnoGoizw65JfGvyMqNGlHdlUXD1VAuxtvYAaHBKLBdKPnpy60XKVDAkQCfmMu53g+gq9FM+ydepw==",
-            "deprecated": "vsce has been renamed to @vscode/vsce. Install using @vscode/vsce instead.",
-            "dev": true,
-            "dependencies": {
-                "azure-devops-node-api": "^11.0.1",
-                "chalk": "^2.4.2",
-                "cheerio": "^1.0.0-rc.9",
-                "commander": "^6.1.0",
-                "glob": "^7.0.6",
-                "hosted-git-info": "^4.0.2",
-                "keytar": "^7.7.0",
-                "leven": "^3.1.0",
-                "markdown-it": "^12.3.2",
-                "mime": "^1.3.4",
-                "minimatch": "^3.0.3",
-                "parse-semver": "^1.1.1",
-                "read": "^1.0.7",
-                "semver": "^5.1.0",
-                "tmp": "^0.2.1",
-                "typed-rest-client": "^1.8.4",
-                "url-join": "^4.0.1",
-                "xml2js": "^0.4.23",
-                "yauzl": "^2.3.1",
-                "yazl": "^2.2.2"
-            },
-            "bin": {
-                "vsce": "vsce"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/vsce/node_modules/commander": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/vsce/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "dev": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/vsce/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
         "node_modules/vscode-jsonrpc": {
             "version": "5.0.1",
             "license": "MIT",
@@ -3790,6 +3867,7 @@
             "version": "1.1.5",
             "dev": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "string-width": "^1.0.2 || 2 || 3 || 4"
             }
@@ -3889,19 +3967,6 @@
             "version": "1.0.2",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/xml2js": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-            "dev": true,
-            "dependencies": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "~11.0.0"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
         },
         "node_modules/xmlbuilder": {
             "version": "11.0.1",
@@ -4202,12 +4267,82 @@
                     }
                 },
                 "semver": {
-                    "version": "7.5.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-                    "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "@vscode/vsce": {
+            "version": "2.21.0",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.21.0.tgz",
+            "integrity": "sha512-KuxYqScqUY/duJbkj9eE2tN2X/WJoGAy54hHtxT3ZBkM6IzrOg7H7CXGUPBxNlmqku2w/cAjOUSrgIHlzz0mbA==",
+            "dev": true,
+            "requires": {
+                "azure-devops-node-api": "^11.0.1",
+                "chalk": "^2.4.2",
+                "cheerio": "^1.0.0-rc.9",
+                "commander": "^6.2.1",
+                "glob": "^7.0.6",
+                "hosted-git-info": "^4.0.2",
+                "jsonc-parser": "^3.2.0",
+                "keytar": "^7.7.0",
+                "leven": "^3.1.0",
+                "markdown-it": "^12.3.2",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.3",
+                "parse-semver": "^1.1.1",
+                "read": "^1.0.7",
+                "semver": "^7.5.2",
+                "tmp": "^0.2.1",
+                "typed-rest-client": "^1.8.4",
+                "url-join": "^4.0.1",
+                "xml2js": "^0.5.0",
+                "yauzl": "^2.3.1",
+                "yazl": "^2.2.2"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+                    "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+                    "dev": true
+                },
+                "glob": {
+                    "version": "7.2.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.1.1",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "xml2js": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+                    "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+                    "dev": true,
+                    "requires": {
+                        "sax": ">=0.6.0",
+                        "xmlbuilder": "~11.0.0"
                     }
                 }
             }
@@ -4231,7 +4366,8 @@
         },
         "ansi-regex": {
             "version": "2.1.1",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "ansi-styles": {
             "version": "3.2.1",
@@ -4250,11 +4386,13 @@
         },
         "aproba": {
             "version": "1.2.0",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "are-we-there-yet": {
             "version": "1.1.7",
             "dev": true,
+            "optional": true,
             "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -4288,7 +4426,8 @@
         },
         "base64-js": {
             "version": "1.5.1",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "binary-extensions": {
             "version": "2.2.0",
@@ -4297,6 +4436,7 @@
         "bl": {
             "version": "4.1.0",
             "dev": true,
+            "optional": true,
             "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -4306,6 +4446,7 @@
                 "readable-stream": {
                     "version": "3.6.0",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -4340,6 +4481,7 @@
         "buffer": {
             "version": "5.7.1",
             "dev": true,
+            "optional": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -4447,7 +4589,8 @@
         },
         "chownr": {
             "version": "1.1.4",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "cliui": {
             "version": "7.0.4",
@@ -4486,7 +4629,8 @@
         },
         "code-point-at": {
             "version": "1.1.0",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "color-convert": {
             "version": "1.9.3",
@@ -4517,7 +4661,8 @@
         },
         "console-control-strings": {
             "version": "1.1.0",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "core-util-is": {
             "version": "1.0.3",
@@ -4592,6 +4737,7 @@
         "decompress-response": {
             "version": "4.2.1",
             "dev": true,
+            "optional": true,
             "requires": {
                 "mimic-response": "^2.0.0"
             }
@@ -4607,15 +4753,18 @@
         },
         "deep-extend": {
             "version": "0.6.0",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "delegates": {
             "version": "1.0.0",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "detect-libc": {
             "version": "1.0.3",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "diff": {
             "version": "4.0.2",
@@ -4657,6 +4806,7 @@
         "end-of-stream": {
             "version": "1.4.4",
             "dev": true,
+            "optional": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -4859,7 +5009,8 @@
         },
         "expand-template": {
             "version": "2.0.3",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "fd-slicer": {
             "version": "1.1.0",
@@ -4910,7 +5061,8 @@
         },
         "fs-constants": {
             "version": "1.0.0",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -4923,6 +5075,7 @@
         "gauge": {
             "version": "2.7.4",
             "dev": true,
+            "optional": true,
             "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -4953,7 +5106,8 @@
         },
         "github-from-package": {
             "version": "0.0.0",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "glob": {
             "version": "8.1.0",
@@ -5014,7 +5168,8 @@
         },
         "has-unicode": {
             "version": "2.0.1",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "he": {
             "version": "1.2.0",
@@ -5039,7 +5194,8 @@
         },
         "ieee754": {
             "version": "1.2.1",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "immediate": {
             "version": "3.0.6",
@@ -5067,7 +5223,8 @@
         },
         "ini": {
             "version": "1.3.8",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -5098,6 +5255,7 @@
         "is-fullwidth-code-point": {
             "version": "1.0.0",
             "dev": true,
+            "optional": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
@@ -5147,6 +5305,12 @@
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
+        "jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "dev": true
+        },
         "jszip": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -5162,6 +5326,7 @@
         "keytar": {
             "version": "7.7.0",
             "dev": true,
+            "optional": true,
             "requires": {
                 "node-addon-api": "^3.0.0",
                 "prebuild-install": "^6.0.0"
@@ -5351,7 +5516,8 @@
         },
         "mimic-response": {
             "version": "2.1.0",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "min-indent": {
             "version": "1.0.1",
@@ -5400,7 +5566,8 @@
         },
         "mkdirp-classic": {
             "version": "0.5.3",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "mocha": {
             "version": "10.2.0",
@@ -5639,7 +5806,8 @@
         },
         "napi-build-utils": {
             "version": "1.0.2",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "ncp": {
             "version": "2.0.0",
@@ -5665,19 +5833,24 @@
         "node-abi": {
             "version": "2.30.1",
             "dev": true,
+            "optional": true,
             "requires": {
                 "semver": "^5.4.1"
             },
             "dependencies": {
                 "semver": {
-                    "version": "5.7.1",
-                    "dev": true
+                    "version": "5.7.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+                    "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
         "node-addon-api": {
             "version": "3.2.1",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "node-domexception": {
             "version": "1.0.0",
@@ -5715,9 +5888,9 @@
                     "dev": true
                 },
                 "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "version": "5.7.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+                    "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
                     "dev": true
                 }
             }
@@ -5729,6 +5902,7 @@
         "npmlog": {
             "version": "4.1.2",
             "dev": true,
+            "optional": true,
             "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -5745,11 +5919,13 @@
         },
         "number-is-nan": {
             "version": "1.0.1",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "object-assign": {
             "version": "4.1.1",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "object-inspect": {
             "version": "1.11.1",
@@ -5812,7 +5988,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "5.7.1",
+                    "version": "5.7.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+                    "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
                     "dev": true
                 }
             }
@@ -5867,6 +6045,7 @@
         "prebuild-install": {
             "version": "6.1.4",
             "dev": true,
+            "optional": true,
             "requires": {
                 "detect-libc": "^1.0.3",
                 "expand-template": "^2.0.3",
@@ -5896,6 +6075,7 @@
         "pump": {
             "version": "3.0.0",
             "dev": true,
+            "optional": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -5924,6 +6104,7 @@
         "rc": {
             "version": "1.2.8",
             "dev": true,
+            "optional": true,
             "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -6056,7 +6237,9 @@
             "dev": true
         },
         "semver": {
-            "version": "6.3.0"
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         },
         "serialize-javascript": {
             "version": "6.0.0",
@@ -6067,7 +6250,8 @@
         },
         "set-blocking": {
             "version": "2.0.0",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "setimmediate": {
             "version": "1.0.5",
@@ -6086,15 +6270,18 @@
         },
         "signal-exit": {
             "version": "3.0.7",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "simple-concat": {
             "version": "1.0.1",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "simple-get": {
             "version": "3.1.1",
             "dev": true,
+            "optional": true,
             "requires": {
                 "decompress-response": "^4.2.0",
                 "once": "^1.3.1",
@@ -6154,6 +6341,7 @@
         "string-width": {
             "version": "1.0.2",
             "dev": true,
+            "optional": true,
             "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -6163,6 +6351,7 @@
         "strip-ansi": {
             "version": "3.0.1",
             "dev": true,
+            "optional": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -6178,7 +6367,8 @@
         },
         "strip-json-comments": {
             "version": "2.0.1",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "supports-color": {
             "version": "5.5.0",
@@ -6196,6 +6386,7 @@
         "tar-fs": {
             "version": "2.1.1",
             "dev": true,
+            "optional": true,
             "requires": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -6206,6 +6397,7 @@
         "tar-stream": {
             "version": "2.2.0",
             "dev": true,
+            "optional": true,
             "requires": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -6217,6 +6409,7 @@
                 "readable-stream": {
                     "version": "3.6.0",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -6281,6 +6474,7 @@
         "tunnel-agent": {
             "version": "0.6.0",
             "dev": true,
+            "optional": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -6370,62 +6564,6 @@
                 "spdx-expression-parse": "^3.0.0"
             }
         },
-        "vsce": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.15.0.tgz",
-            "integrity": "sha512-P8E9LAZvBCQnoGoizw65JfGvyMqNGlHdlUXD1VAuxtvYAaHBKLBdKPnpy60XKVDAkQCfmMu53g+gq9FM+ydepw==",
-            "dev": true,
-            "requires": {
-                "azure-devops-node-api": "^11.0.1",
-                "chalk": "^2.4.2",
-                "cheerio": "^1.0.0-rc.9",
-                "commander": "^6.1.0",
-                "glob": "^7.0.6",
-                "hosted-git-info": "^4.0.2",
-                "keytar": "^7.7.0",
-                "leven": "^3.1.0",
-                "markdown-it": "^12.3.2",
-                "mime": "^1.3.4",
-                "minimatch": "^3.0.3",
-                "parse-semver": "^1.1.1",
-                "read": "^1.0.7",
-                "semver": "^5.1.0",
-                "tmp": "^0.2.1",
-                "typed-rest-client": "^1.8.4",
-                "url-join": "^4.0.1",
-                "xml2js": "^0.4.23",
-                "yauzl": "^2.3.1",
-                "yazl": "^2.2.2"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "6.2.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-                    "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-                    "dev": true
-                },
-                "glob": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.1.1",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
-                }
-            }
-        },
         "vscode-jsonrpc": {
             "version": "5.0.1"
         },
@@ -6476,6 +6614,7 @@
         "wide-align": {
             "version": "1.1.5",
             "dev": true,
+            "optional": true,
             "requires": {
                 "string-width": "^1.0.2 || 2 || 3 || 4"
             }
@@ -6540,16 +6679,6 @@
         "wrappy": {
             "version": "1.0.2",
             "dev": true
-        },
-        "xml2js": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-            "dev": true,
-            "requires": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "~11.0.0"
-            }
         },
         "xmlbuilder": {
             "version": "11.0.1",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
         "@types/vscode": "^1.49.0",
         "@types/which": "^2.0.1",
         "@vscode/test-electron": "^2.1.3",
+        "@vscode/vsce": "^2.21.0",
         "chai": "^4.3.4",
         "chai-spies": "^1.0.0",
         "colorette": "^2.0.16",
@@ -153,7 +154,6 @@
         "ts-node": "^10.9.1",
         "typescript": "^4.6.4",
         "url-exist": "^3.0.0",
-        "vsce": "^2.15.0",
         "vscode-oniguruma": "^1.7.0",
         "vscode-textmate": "^9.0.0",
         "which": "^2.0.2"


### PR DESCRIPTION
...as suggested by `npm`. This also bumps `vsce` to `2.21.0`.