### PR TITLE
Fix rust setup action in CI

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -60,9 +60,9 @@ runs:
       shell: bash
       if: ${{ inputs.partial == 'false' }}
     - name: Setup Rust
-      uses: ATiltedTree/setup-rust@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        rust-version: stable
+        toolchain: stable
         components: clippy
       if: ${{ inputs.partial == 'false' }}
     - name: Install RTI


### PR DESCRIPTION
The action ATiltedTree/setup-rust disappeared overnight. This PR switches to another action.