### PR TITLE
Adjustment of version numbers for nightly releases

### DIFF
--- a/.github/scripts/nightly-version.sh
+++ b/.github/scripts/nightly-version.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
-
-# Set a new version number based on the next minor version,
-# combined with a patch version based on the current date.
-npm version minor --no-git-tag-version > /dev/null 2>&1
 version=$(echo "$(npm pkg get version)" | tr -d '"')
 date=$(date +%Y%m%d)
 
-# NOTE: the following assumes that only simple
-# major.minor.patch version numbers are being used.
+# Determine a new version number by using the current date as a patch number
+# (the following assumes that only major.minor.patch version numbers are used).
 nightly="${version%.*}.$date"
 npm version $nightly --no-git-tag-version
 


### PR DESCRIPTION
Fixes #170. To be merged on the day that `v0.9.0` is published.