### PR TITLE
Update documentation link

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
         "viewsWelcome": [
             {
               "view": "lf-lang-projects",
-              "contents": "No Lingua Franca project found. [Learn more](https://www.lf-lang.org/docs/) about setting up a Lingua Franca project structure.\n[Open Lingua Franca Project](command:linguafranca.openFolder)"
+              "contents": "No Lingua Franca project found. [Learn more](https://www.lf-lang.org/docs/tools/code-extension) about setting up a Lingua Franca project structure.\n[Open Lingua Franca Project](command:linguafranca.openFolder)"
             }
           ]
     },


### PR DESCRIPTION
This PR updates the link in the error message when a project doesn’t comply with the correct Lingua Franca project structure. This allows developers to directly click the link and access the relevant documentation for more information.

![error_message](https://github.com/user-attachments/assets/a20c5f46-0e0e-445c-9de0-c99eeac1c7fe)
