### PR TITLE
Resolve goToLingoToml for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,11 +224,6 @@
                     "when": "viewItem == project"
                 },
                 {
-                    "command": "linguafranca.includeProject",
-                    "group": "inline@1",
-                    "when": "viewItem == root || viewItem == file-local"
-                },
-                {
                     "command": "linguafranca.goToFile",
                     "group": "inline@2",
                     "when": "viewItem == file-local || viewItem == file-lingo || viewItem == file-local-included || viewItem == reactor || viewItem == reactor-included"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,6 @@ import { registerCollapseAllCommand,
     registerGoToFileCommand,
     registerGoToLingoTomlCommand,
     registerImportReactorCommand,
-    registerIncludeProjectCommand,
     registerOpenFolderCommand,
     registerOpenInSplitViewCommand,
     registerOpenInTerminalCommand,
@@ -98,7 +97,6 @@ export async function activate(context: vscode.ExtensionContext) {
     registerImportReactorCommand(context, lfDataProvider);
     registerCollapseAllCommand(context);
     registerGoToLingoTomlCommand(context, lfDataProvider);
-    registerIncludeProjectCommand(context, lfDataProvider);
     registerOpenInTerminalCommand(context);
     registerOpenFolderCommand(context);
 

--- a/src/lfview/lf-data-provider-commands.ts
+++ b/src/lfview/lf-data-provider-commands.ts
@@ -79,18 +79,6 @@ export function registerGoToLingoTomlCommand(context: vscode.ExtensionContext, p
     ));
 }
 
-export function registerIncludeProjectCommand(context: vscode.ExtensionContext, provider: LFDataProvider) {
-    context.subscriptions.push(vscode.commands.registerCommand(
-        'linguafranca.includeProject', (node: LFDataProviderNode) => {
-            vscode.window.showInformationMessage('The "Include Project" feature is not implemented yet.', 'Details').then(selection => {
-                if (selection === "Details") {
-                vscode.window.showInformationMessage('Please use the Lingo command line to include the selected library in your current project. Once included, the library will appear under the "Lingo Packages" section.');
-                }
-            });
-        }
-    ));
-}
-
 export function registerOpenInTerminalCommand(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand(
         'linguafranca.openInTerminal', (node: LFDataProviderNode) => {

--- a/src/lfview/lf-data-provider-commands.ts
+++ b/src/lfview/lf-data-provider-commands.ts
@@ -49,11 +49,17 @@ export function registerOpenInSplitViewCommand(context: vscode.ExtensionContext,
 export function registerImportReactorCommand(context: vscode.ExtensionContext, provider: LFDataProvider) {
     context.subscriptions.push(vscode.commands.registerCommand(
         'linguafranca.importReactor', async (node: LFDataProviderNode) => {
-            if(node.type === LFDataProviderNodeType.LOCAL) {
-                await provider.importReactorCommand(node);
+            const editor = vscode.window.activeTextEditor;
+
+            if (!editor) {
+                vscode.window.showErrorMessage('No active editor found.');
+                return;
             }
-            else {
-                await provider.importLibraryReactorCommand(node);
+
+            if (node.type === LFDataProviderNodeType.LOCAL) {
+                await provider.importReactorCommand(node, editor);
+            } else {
+                await provider.importLibraryReactorCommand(node, editor);
             }
         }
     ));

--- a/src/lfview/lf-data-provider.ts
+++ b/src/lfview/lf-data-provider.ts
@@ -796,7 +796,7 @@ export class LFDataProvider implements vscode.TreeDataProvider<LFDataProviderNod
      * @param node - The LFDataProviderNode for which to open the Lingo.toml file.
      */
     goToLingoTomlCommand(node: LFDataProviderNode) {
-        const segments = node.uri.fsPath.split('/');
+        const segments = node.uri.path.split('/');
         const srcIdx = segments.lastIndexOf('build');
     
         if (srcIdx === -1) {
@@ -804,7 +804,7 @@ export class LFDataProvider implements vscode.TreeDataProvider<LFDataProviderNod
             return;
         }
     
-        let newUri = segments.slice(0, srcIdx).join('/').concat('/Lingo.toml');
+        let newUri = segments.slice(0, srcIdx).join(path.sep).concat(`${path.sep}Lingo.toml`);
         
         vscode.workspace.openTextDocument(vscode.Uri.file(newUri))
             .then(doc => {

--- a/src/lfview/lf-data-provider.ts
+++ b/src/lfview/lf-data-provider.ts
@@ -674,18 +674,15 @@ export class LFDataProvider implements vscode.TreeDataProvider<LFDataProviderNod
      * @param node - The node representing the reactor to import.
      * @returns A Promise that resolves when the import text has been added to the active editor and the document saved.
      */
-    async importReactorCommand(node: LFDataProviderNode) {
-        const editor = vscode.window.activeTextEditor;
-        if (editor) {
-            if (!editor.document.uri.fsPath.endsWith('.lf')) {
-                vscode.window.showErrorMessage('The active editor must be a Ligua Franca program.');
-                return;
-            }
-            const relativePath = this.getRelativePath(editor.document.uri.path, node.uri.path);
-            const importText = `import ${node.label!.toString()} from "${relativePath}"\n`;
-            const position = await this.getTargetPosition(editor.document.uri);
-            this.addTextOnActiveEditor(editor, position!.end, importText);
+    async importReactorCommand(node: LFDataProviderNode, editor: vscode.TextEditor): Promise<void> {
+        if (!editor.document.uri.path.endsWith('.lf')) {
+            vscode.window.showErrorMessage('The active editor must be a Ligua Franca program.');
+            return;
         }
+        const relativePath = this.getRelativePath(editor.document.uri.path, node.uri.path);
+        const importText = `import ${node.label!.toString()} from "${relativePath}"\n`;
+        const position = await this.getTargetPosition(editor.document.uri);
+        this.addTextOnActiveEditor(editor, position!.end, importText);
     }
 
     /**
@@ -695,18 +692,15 @@ export class LFDataProvider implements vscode.TreeDataProvider<LFDataProviderNod
      * @param node - The node representing the reactor to import.
      * @returns A Promise that resolves when the import text has been added to the active editor and the document saved.
      */
-    async importLibraryReactorCommand(node: LFDataProviderNode) {
-        const editor = vscode.window.activeTextEditor;
-        if (editor) {
-            if (!editor.document.uri.fsPath.endsWith('.lf')) {
-                vscode.window.showErrorMessage('The active editor must be a Ligua Franca program.');
-                return;
-            }
-            const relativePath = this.getLibraryPath(node.uri.path);
-            const importText = `import ${node.label!.toString()} from <${relativePath}>\n`;
-            const position = await this.getTargetPosition(editor.document.uri);
-            this.addTextOnActiveEditor(editor, position!.end, importText);
+    async importLibraryReactorCommand(node: LFDataProviderNode, editor: vscode.TextEditor): Promise<void> {
+        if (!editor.document.uri.fsPath.endsWith('.lf')) {
+            vscode.window.showErrorMessage('The active editor must be a Ligua Franca program.');
+            return;
         }
+        const relativePath = this.getLibraryPath(node.uri.path);
+        const importText = `import ${node.label!.toString()} from <${relativePath}>\n`;
+        const position = await this.getTargetPosition(editor.document.uri);
+        this.addTextOnActiveEditor(editor, position!.end, importText);
     }
 
     /**


### PR DESCRIPTION
This PR fixes the action that navigates to the project’s `Lingo.toml` and removes an unused command.