### PR TITLE
Support .ulf filename extension and micro-LF build and run.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
                     "Lingua Franca"
                 ],
                 "extensions": [
-                    ".lf"
+                    ".lf",
+                    ".ulf"
                 ],
                 "configuration": "./language-configuration.json"
             }

--- a/src/build_commands.ts
+++ b/src/build_commands.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import which from 'which';
+import { execFile } from 'child_process';
 import { LanguageClient } from 'vscode-languageclient';
 import { getTerminal, MessageDisplayHelper } from './utils';
 
@@ -114,6 +115,35 @@ async function getJson(uri: string): Promise<string> {
 }
 
 /**
+ * Probe the user's interactive login shell for the reactor-uc build environment. Running an
+ * interactive shell ensures that aliases, shell functions, and variables defined in startup
+ * files (e.g. `.zshrc`) are resolved, which is not the case for the extension host's
+ * environment. This mirrors what the integrated terminal will see when it runs the build.
+ * @returns Whether `ulfc` resolves in the shell and the value of `REACTOR_UC_PATH`, if any.
+ */
+function probeReactorUcShellEnvironment(): Promise<{ ulfcAvailable: boolean, reactorUcPath: string | undefined }> {
+    return new Promise((resolve) => {
+        const shell = vscode.env.shell || process.env.SHELL;
+        if (!shell) {
+            resolve({ ulfcAvailable: false, reactorUcPath: undefined });
+            return;
+        }
+        // `command -v` resolves aliases, functions, and executables; the marker lines let us
+        // parse the result unambiguously.
+        const script =
+            'command -v ulfc >/dev/null 2>&1 && echo __ULFC_FOUND__; '
+            + 'echo "__REACTOR_UC_PATH__=$REACTOR_UC_PATH"';
+        execFile(shell, ['-ic', script], { timeout: 8000 }, (_error, stdout) => {
+            const out = stdout ?? '';
+            const ulfcAvailable = out.includes('__ULFC_FOUND__');
+            const match = out.match(/__REACTOR_UC_PATH__=(.*)/);
+            const value = match ? match[1].trim() : '';
+            resolve({ ulfcAvailable, reactorUcPath: value.length > 0 ? value : undefined });
+        });
+    });
+}
+
+/**
  * Verify that the environment required to build reactor-uc (`.ulf`) programs is available.
  * Specifically, this checks that the `ulfc` compiler is on the PATH and that the
  * `REACTOR_UC_PATH` environment variable points to a clone of the reactor-uc repository.
@@ -122,16 +152,28 @@ async function getJson(uri: string): Promise<string> {
  * @returns Whether the reactor-uc build environment is satisfied.
  */
 async function checkReactorUcEnvironment(withLogs: MessageShowerTransformer): Promise<boolean> {
-    let ulfc: string | undefined;
+    let ulfcAvailable = false;
     try {
-        ulfc = await which('ulfc');
+        await which('ulfc');
+        ulfcAvailable = true;
     } catch {
-        ulfc = undefined;
+        ulfcAvailable = false;
     }
-    const reactorUcPath = process.env.REACTOR_UC_PATH;
+    let reactorUcPath = process.env.REACTOR_UC_PATH;
+
+    // `ulfc` is frequently provided as a shell alias or function, and `REACTOR_UC_PATH` may be
+    // exported only in shell startup files. Neither is visible to the extension host's PATH/env,
+    // so fall back to probing the user's interactive login shell (which is also what the
+    // integrated terminal uses to actually run the build).
+    if (!ulfcAvailable || !reactorUcPath) {
+        const probe = await probeReactorUcShellEnvironment();
+        ulfcAvailable = ulfcAvailable || probe.ulfcAvailable;
+        reactorUcPath = reactorUcPath || probe.reactorUcPath;
+    }
+
     const problems: string[] = [];
-    if (!ulfc) {
-        problems.push('the `ulfc` compiler could not be found on your PATH');
+    if (!ulfcAvailable) {
+        problems.push('the `ulfc` compiler could not be found');
     }
     if (!reactorUcPath) {
         problems.push('the `REACTOR_UC_PATH` environment variable is not set');

--- a/src/build_commands.ts
+++ b/src/build_commands.ts
@@ -195,7 +195,7 @@ async function checkReactorUcEnvironment(withLogs: MessageShowerTransformer): Pr
  * @param textEditor The editor containing the `.ulf` file to build.
  */
 async function buildReactorUc(withLogs: MessageShowerTransformer, textEditor: vscode.TextEditor) {
-    const successful = vscode.workspace.saveAll();
+    const successful = await vscode.workspace.saveAll();
     if (!successful) return;
     if (!(await checkReactorUcEnvironment(withLogs))) return;
     const filePath = textEditor.document.uri.fsPath;

--- a/src/build_commands.ts
+++ b/src/build_commands.ts
@@ -1,6 +1,20 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
+import which from 'which';
 import { LanguageClient } from 'vscode-languageclient';
 import { getTerminal, MessageDisplayHelper } from './utils';
+
+/** The repository that provides the `ulfc` compiler for the reactor-uc target. */
+const REACTOR_UC_REPO = 'https://github.com/lf-lang/reactor-uc';
+
+/**
+ * Return whether the given document is a reactor-uc Lingua Franca file (i.e. has a `.ulf`
+ * extension), which is compiled with `ulfc` rather than the standard build pipeline.
+ * @param textDocument A document in the user's editor.
+ */
+function isUlfDocument(textDocument: vscode.TextDocument): boolean {
+    return textDocument.uri.toString().endsWith('.ulf');
+}
 
 /**
  * Return the URI of the given document, if the document is a Lingua Franca file; else, return
@@ -11,7 +25,7 @@ import { getTerminal, MessageDisplayHelper } from './utils';
  */
 function getLfUri(textDocument: vscode.TextDocument, failSilently = false): string | undefined {
     const uri: string = textDocument.uri.toString();
-    if (!uri.endsWith('.lf')) {
+    if (!uri.endsWith('.lf') && !uri.endsWith('.ulf')) {
         if (!failSilently) {
             vscode.window.showErrorMessage(
                 'The currently active file is not a Lingua Franca source file.'
@@ -52,7 +66,7 @@ const getWorkspace =
     if (roots) {
       for (const root of roots) {
         const files: vscode.Uri[] = await vscode.workspace.findFiles(
-            new vscode.RelativePattern(root, "**/*.lf")
+            new vscode.RelativePattern(root, "**/*.{lf,ulf}")
         );
         lf_files = lf_files.concat(files);
         lingo_tomls = lingo_tomls.concat(await vscode.workspace.findFiles(
@@ -100,6 +114,57 @@ async function getJson(uri: string): Promise<string> {
 }
 
 /**
+ * Verify that the environment required to build reactor-uc (`.ulf`) programs is available.
+ * Specifically, this checks that the `ulfc` compiler is on the PATH and that the
+ * `REACTOR_UC_PATH` environment variable points to a clone of the reactor-uc repository.
+ * If either is missing, an error message is shown that points to the repository.
+ * @param withLogs A messageShowerTransformer that lets the user request to view logs.
+ * @returns Whether the reactor-uc build environment is satisfied.
+ */
+async function checkReactorUcEnvironment(withLogs: MessageShowerTransformer): Promise<boolean> {
+    let ulfc: string | undefined;
+    try {
+        ulfc = await which('ulfc');
+    } catch {
+        ulfc = undefined;
+    }
+    const reactorUcPath = process.env.REACTOR_UC_PATH;
+    const problems: string[] = [];
+    if (!ulfc) {
+        problems.push('the `ulfc` compiler could not be found on your PATH');
+    }
+    if (!reactorUcPath) {
+        problems.push('the `REACTOR_UC_PATH` environment variable is not set');
+    }
+    if (problems.length > 0) {
+        withLogs(vscode.window.showErrorMessage)(
+            `Cannot build this reactor-uc (.ulf) program because ${problems.join(' and ')}. `
+            + `Install the reactor-uc compiler and set REACTOR_UC_PATH to a clone of `
+            + `${REACTOR_UC_REPO}.`
+        );
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Build (and, if requested, run) a reactor-uc (`.ulf`) program using the `ulfc` compiler.
+ * @param withLogs A messageShowerTransformer that lets the user request to view logs.
+ * @param textEditor The editor containing the `.ulf` file to build.
+ */
+async function buildReactorUc(withLogs: MessageShowerTransformer, textEditor: vscode.TextEditor) {
+    const successful = vscode.workspace.saveAll();
+    if (!successful) return;
+    if (!(await checkReactorUcEnvironment(withLogs))) return;
+    const filePath = textEditor.document.uri.fsPath;
+    const cwd = path.dirname(filePath);
+    const terminal = getTerminal('Lingua Franca: Run', cwd);
+    terminal.show(true);
+    terminal.sendText(`cd "${cwd}"`);
+    terminal.sendText(`ulfc "${filePath}"`);
+}
+
+/**
  * Return the action that should be taken in case of a request to build.
  * @param withLogs A messageShowerTransformer that lets the user request to view logs.
  * @param client The language client.
@@ -109,6 +174,10 @@ const build = (withLogs: MessageShowerTransformer, client: LanguageClient) =>
         async (textEditor: vscode.TextEditor) => {
     const uri = getLfUri(textEditor.document);
     if (!uri) return;
+    if (isUlfDocument(textEditor.document)) {
+        await buildReactorUc(withLogs, textEditor);
+        return;
+    }
     const successful = vscode.workspace.saveAll();
     if (!successful) return;
     const args = {"uri": uri, "json": await getJson(uri)};
@@ -130,6 +199,10 @@ const buildAndRun = (withLogs: MessageShowerTransformer, client: LanguageClient)
         async (textEditor: vscode.TextEditor) => {
     const uri = getLfUri(textEditor.document);
     if (!uri) return;
+    if (isUlfDocument(textEditor.document)) {
+        await buildReactorUc(withLogs, textEditor);
+        return;
+    }
     const successful = vscode.workspace.saveAll();
     if (!successful) {
         return;
@@ -188,6 +261,8 @@ export function registerBuildCommands(context: vscode.ExtensionContext, client: 
         if (!enabled) return;
         const uri = getLfUri(textDocument, true);
         if (!uri) return; // This is not an LF document, so do nothing.
+        // reactor-uc (.ulf) files are built with `ulfc`, not the standard build pipeline.
+        if (isUlfDocument(textDocument)) return;
         client.sendNotification('generator/partialBuild', uri);
     });
     vscode.workspace.onDidChangeConfiguration(() => {

--- a/src/build_commands.ts
+++ b/src/build_commands.ts
@@ -245,7 +245,7 @@ const buildAndRun = (withLogs: MessageShowerTransformer, client: LanguageClient)
         await buildReactorUc(withLogs, textEditor);
         return;
     }
-    const successful = vscode.workspace.saveAll();
+    const successful = await vscode.workspace.saveAll();
     if (!successful) {
         return;
     }

--- a/src/build_commands.ts
+++ b/src/build_commands.ts
@@ -220,7 +220,7 @@ const build = (withLogs: MessageShowerTransformer, client: LanguageClient) =>
         await buildReactorUc(withLogs, textEditor);
         return;
     }
-    const successful = vscode.workspace.saveAll();
+    const successful = await vscode.workspace.saveAll();
     if (!successful) return;
     const args = {"uri": uri, "json": await getJson(uri)};
     // const args = [ uri, await getJson(uri)];

--- a/src/build_commands.ts
+++ b/src/build_commands.ts
@@ -5,11 +5,11 @@ import { execFile } from 'child_process';
 import { LanguageClient } from 'vscode-languageclient';
 import { getTerminal, MessageDisplayHelper } from './utils';
 
-/** The repository that provides the `ulfc` compiler for the reactor-uc target. */
+/** The repository that provides the `ulfc` compiler for the micro-LF. */
 const REACTOR_UC_REPO = 'https://github.com/lf-lang/reactor-uc';
 
 /**
- * Return whether the given document is a reactor-uc Lingua Franca file (i.e. has a `.ulf`
+ * Return whether the given document is a micro-LF Lingua Franca file (i.e. has a `.ulf`
  * extension), which is compiled with `ulfc` rather than the standard build pipeline.
  * @param textDocument A document in the user's editor.
  */
@@ -115,7 +115,7 @@ async function getJson(uri: string): Promise<string> {
 }
 
 /**
- * Probe the user's interactive login shell for the reactor-uc build environment. Running an
+ * Probe the user's interactive login shell for the micro-LF build environment. Running an
  * interactive shell ensures that aliases, shell functions, and variables defined in startup
  * files (e.g. `.zshrc`) are resolved, which is not the case for the extension host's
  * environment. This mirrors what the integrated terminal will see when it runs the build.
@@ -144,12 +144,12 @@ function probeReactorUcShellEnvironment(): Promise<{ ulfcAvailable: boolean, rea
 }
 
 /**
- * Verify that the environment required to build reactor-uc (`.ulf`) programs is available.
+ * Verify that the environment required to build micro-LF (`.ulf`) programs is available.
  * Specifically, this checks that the `ulfc` compiler is on the PATH and that the
- * `REACTOR_UC_PATH` environment variable points to a clone of the reactor-uc repository.
+ * `REACTOR_UC_PATH` environment variable points to a clone of the micro-LF repository.
  * If either is missing, an error message is shown that points to the repository.
  * @param withLogs A messageShowerTransformer that lets the user request to view logs.
- * @returns Whether the reactor-uc build environment is satisfied.
+ * @returns Whether the micro-LF build environment is satisfied.
  */
 async function checkReactorUcEnvironment(withLogs: MessageShowerTransformer): Promise<boolean> {
     let ulfcAvailable = false;
@@ -180,8 +180,8 @@ async function checkReactorUcEnvironment(withLogs: MessageShowerTransformer): Pr
     }
     if (problems.length > 0) {
         withLogs(vscode.window.showErrorMessage)(
-            `Cannot build this reactor-uc (.ulf) program because ${problems.join(' and ')}. `
-            + `Install the reactor-uc compiler and set REACTOR_UC_PATH to a clone of `
+            `Cannot build this micro-LF (.ulf) program because ${problems.join(' and ')}. `
+            + `Install the micro-LF compiler and set REACTOR_UC_PATH to a clone of `
             + `${REACTOR_UC_REPO}.`
         );
         return false;
@@ -190,7 +190,7 @@ async function checkReactorUcEnvironment(withLogs: MessageShowerTransformer): Pr
 }
 
 /**
- * Build (and, if requested, run) a reactor-uc (`.ulf`) program using the `ulfc` compiler.
+ * Build (and, if requested, run) a micro-LF (`.ulf`) program using the `ulfc` compiler.
  * @param withLogs A messageShowerTransformer that lets the user request to view logs.
  * @param textEditor The editor containing the `.ulf` file to build.
  */
@@ -303,7 +303,7 @@ export function registerBuildCommands(context: vscode.ExtensionContext, client: 
         if (!enabled) return;
         const uri = getLfUri(textDocument, true);
         if (!uri) return; // This is not an LF document, so do nothing.
-        // reactor-uc (.ulf) files are built with `ulfc`, not the standard build pipeline.
+        // micro-LF (.ulf) files are built with `ulfc`, not the standard build pipeline.
         if (isUlfDocument(textDocument)) return;
         client.sendNotification('generator/partialBuild', uri);
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,7 +66,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const refId = await vscode.commands.executeCommand(
         'klighd-vscode.setLanguageClient',
         client,
-        ['lf']
+        ['lf', 'ulf']
     );
 
     client.start();

--- a/src/lfview/lf-data-provider.ts
+++ b/src/lfview/lf-data-provider.ts
@@ -60,7 +60,7 @@ export class LFDataProviderNode extends vscode.TreeItem {
         type?: LFDataProviderNodeType | undefined,
         children?: LFDataProviderNode[] | undefined,
         position?: NodePosition | undefined) {
-        let newLabel = type === LFDataProviderNodeType.SOURCE ? label : label.replace('.lf', '');
+        let newLabel = type === LFDataProviderNodeType.SOURCE ? label : label.replace(/\.u?lf$/, '');
         super(newLabel, role === LFDataProviderNodeRole.REACTOR ||
             (role === LFDataProviderNodeRole.FILE && type === LFDataProviderNodeType.SOURCE)
             ? vscode.TreeItemCollapsibleState.None : vscode.TreeItemCollapsibleState.Collapsed);
@@ -221,9 +221,9 @@ export class LFDataProvider implements vscode.TreeDataProvider<LFDataProviderNod
     private data: LFDataProviderNode[] = [];
 
     // Utility properties
-    private searchSourceFiles: vscode.GlobPattern = 'src/**/*.lf}';
-    private searchPathLocal: vscode.GlobPattern = 'src/lib/*.lf';
-    private searchPathLibrary: vscode.GlobPattern = 'build/lfc_include/**/src/lib/*.lf';
+    private searchSourceFiles: vscode.GlobPattern = 'src/**/*.{lf,ulf}';
+    private searchPathLocal: vscode.GlobPattern = 'src/lib/*.{lf,ulf}';
+    private searchPathLibrary: vscode.GlobPattern = 'build/lfc_include/**/src/lib/*.{lf,ulf}';
     private exclude_path_local: vscode.GlobPattern = '**/build/**'; // only for local LF libraries
     private exclude_path_src: vscode.GlobPattern = `{${this.exclude_path_local},src/lib/**,**/fed-gen/**,**/src-gen/**}`
 
@@ -286,7 +286,7 @@ export class LFDataProvider implements vscode.TreeDataProvider<LFDataProviderNod
      * @param context - The extension context, used to manage the subscriptions.
      */
     watchFileChanges(context: vscode.ExtensionContext): void {
-        this.watcher = vscode.workspace.createFileSystemWatcher(`**/*.lf`, false, false, false);
+        this.watcher = vscode.workspace.createFileSystemWatcher(`**/*.{lf,ulf}`, false, false, false);
         this.watcher.onDidChange(() => {
             this.refreshTree();
         }),
@@ -675,7 +675,7 @@ export class LFDataProvider implements vscode.TreeDataProvider<LFDataProviderNod
      * @returns A Promise that resolves when the import text has been added to the active editor and the document saved.
      */
     async importReactorCommand(node: LFDataProviderNode, editor: vscode.TextEditor): Promise<void> {
-        if (!editor.document.uri.path.endsWith('.lf')) {
+        if (!editor.document.uri.path.endsWith('.lf') && !editor.document.uri.path.endsWith('.ulf')) {
             vscode.window.showErrorMessage('The active editor must be a Ligua Franca program.');
             return;
         }
@@ -693,7 +693,7 @@ export class LFDataProvider implements vscode.TreeDataProvider<LFDataProviderNod
      * @returns A Promise that resolves when the import text has been added to the active editor and the document saved.
      */
     async importLibraryReactorCommand(node: LFDataProviderNode, editor: vscode.TextEditor): Promise<void> {
-        if (!editor.document.uri.fsPath.endsWith('.lf')) {
+        if (!editor.document.uri.fsPath.endsWith('.lf') && !editor.document.uri.fsPath.endsWith('.ulf')) {
             vscode.window.showErrorMessage('The active editor must be a Ligua Franca program.');
             return;
         }

--- a/src/lfview/lf-data-provider.ts
+++ b/src/lfview/lf-data-provider.ts
@@ -281,7 +281,8 @@ export class LFDataProvider implements vscode.TreeDataProvider<LFDataProviderNod
     }
 
     /**
-     * Subscribes to various file change events (delete, rename, create) and refreshes the LF data provider tree when an .lf file is affected.
+     * Subscribes to various file change events (delete, rename, create) and refreshes the LF data provider tree when an 
+     * .lf or .ulf file is affected.
      * Also subscribes to changes in the LF watcher and refreshes the tree when a change is detected.
      * @param context - The extension context, used to manage the subscriptions.
      */

--- a/src/lfview/lf-data-provider.ts
+++ b/src/lfview/lf-data-provider.ts
@@ -676,7 +676,7 @@ export class LFDataProvider implements vscode.TreeDataProvider<LFDataProviderNod
      */
     async importReactorCommand(node: LFDataProviderNode, editor: vscode.TextEditor): Promise<void> {
         if (!editor.document.uri.path.endsWith('.lf') && !editor.document.uri.path.endsWith('.ulf')) {
-            vscode.window.showErrorMessage('The active editor must be a Ligua Franca program.');
+            vscode.window.showErrorMessage('The active editor must be a Lingua Franca program.');
             return;
         }
         const relativePath = this.getRelativePath(editor.document.uri.path, node.uri.path);

--- a/src/lfview/lf-data-provider.ts
+++ b/src/lfview/lf-data-provider.ts
@@ -694,7 +694,7 @@ export class LFDataProvider implements vscode.TreeDataProvider<LFDataProviderNod
      */
     async importLibraryReactorCommand(node: LFDataProviderNode, editor: vscode.TextEditor): Promise<void> {
         if (!editor.document.uri.fsPath.endsWith('.lf') && !editor.document.uri.fsPath.endsWith('.ulf')) {
-            vscode.window.showErrorMessage('The active editor must be a Ligua Franca program.');
+            vscode.window.showErrorMessage('The active editor must be a Lingua Franca program.');
             return;
         }
         const relativePath = this.getLibraryPath(node.uri.path);


### PR DESCRIPTION
This PR adds support in the VS Code and Cursor extensions for micro-LF.

* Files with `.ulf` extension are recognized as Lingua Franca files, so syntax highlighting and diagram generation work.
* The `Lingua Franca Build and Run` command is adapted to check that a `ulfc` command is found and that the `REACTOR_UC_PATH` environment variable is set.  If not, an error message like the following appears.

<img width="467" height="219" alt="image" src="https://github.com/user-attachments/assets/4ae72aae-0f97-4581-a137-a15de6400778" />

The companion PR in lingua-franca (https://github.com/lf-lang/lingua-franca/pull/2646) should be merged first and the lingua-franca submodule here should be pointed back to master.